### PR TITLE
Spelling correction

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-f.lux - Better lightning for your computer
+f.lux - Better lighting for your computer
 Copyright 2009 - 2010 Michael and Lorna Herf
 
 f.lux indicator applet Copyright (c) 2010 Kilian Valkhof

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 f.lux indicator applet
-Better lightning for your computer
+Better lighting for your computer
 
 f.lux indicator applet is an indicator applet to control xflux, an application
 that makes the color of your computer's display adapt to the time of day, warm

--- a/desktop/fluxgui.desktop
+++ b/desktop/fluxgui.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=f.lux indicator applet
-Comment=Better lightning for your computer
+Comment=Better lighting for your computer
 Terminal=false
 Icon=fluxgui
 Exec=fluxgui

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(name = "f.lux indicator applet",
     version = "1.1.8",
-    description = "f.lux indicator applet - better lightning for your computer",
+    description = "f.lux indicator applet - better lighting for your computer",
     author = "Kilian Valkhof, Michael and Lorna Herf",
     author_email = "kilian@kilianvalkhof.com",
     url = "http://www.stereopsis.com/flux/",

--- a/src/fluxgui/preferences.glade
+++ b/src/fluxgui/preferences.glade
@@ -162,7 +162,7 @@
               <widget class="GtkLabel" id="label3">
                 <property name="visible">True</property>
                 <property name="label" translatable="yes">f.lux
-Better lightning for your computer
+Better lighting for your computer
 Copyright 2009 - 2010 Michael and Lorna Herf
 
 f.lux indicator applet made by Kilian Valkhof</property>


### PR DESCRIPTION
Just changed lightning to lighting to match the slogan on the website: http://stereopsis.com/flux/
