### PR TITLE
Workaround applet crash due to bad config (#66)

### DIFF
--- a/src/fluxgui/fluxapp.py
+++ b/src/fluxgui/fluxapp.py
@@ -165,6 +165,7 @@ class Preferences(object):
         for i, t in self.temperatureKeys.items():
             if t == temperature:
                 return i
+        return 0 # Default value in case 'temperature' is not valid.
 
     def connect_widget(self, widget_name, connect_target=None,
             connect_event="activate"):


### PR DESCRIPTION
See https://github.com/Kilian/f.lux-indicator-applet/issues/66#issuecomment-186770071 for details. I notice that the version of the code I'm editing here has a different list of color temps than the version I have installed locally, so I'm using a default value of 0 since that should always be valid. I'm sad to see that the 2300 temperature option is gone in the current version of the code :(