### PR TITLE
Copy xflux binary instead of renaming it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@
 
 from distutils.core import setup
 from sys import maxsize
-from os import rename
+from shutil import copyfile
 
 # Determines which is the appropriate executable for 32-bit
 if maxsize == 2147483647:
-    rename("xflux32", "xflux")
+    copyfile("xflux32", "xflux")
 # ... or 64-bit processors
 elif maxsize == 9223372036854775807:
-    rename("xflux64", "xflux")
+    copyfile("xflux64", "xflux")
 
 setup(name = "f.lux indicator applet",
     version = "1.1.8",


### PR DESCRIPTION
Passing the os-exception is so solution to this #69.

Moving from renaming to copying won't hurt anyone, except a few bits on your harddisk. :)